### PR TITLE
Use appropriate C compiler flags for debug and release profiles

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -40,10 +40,12 @@ fn compile_chipmunk() {
       let mut conf = gcc::Config::new();
 
       conf.include("chipmunk/include/");
-      conf.flag("-g");
       conf.flag("-std=c99");
 
       if let Ok(profile) = env::var("PROFILE") {
+          if "debug" == profile {
+            conf.flag("-g");
+          }
           if "release" == profile {
               conf.flag("-DNDEBUG");
           }

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,7 @@
 extern crate gcc;
 
+use std::env;
+
 fn compile_chipmunk() {
     let input = [
         "chipmunk/src/chipmunk.c",
@@ -40,6 +42,12 @@ fn compile_chipmunk() {
       conf.include("chipmunk/include/");
       conf.flag("-g");
       conf.flag("-std=c99");
+
+      if let Ok(profile) = env::var("PROFILE") {
+          if "release" == profile {
+              conf.flag("-DNDEBUG");
+          }
+      }
 
       for src in &input {
           conf.file(src);


### PR DESCRIPTION
I have modified the build.rs file to use appropriate C compiler flags when compiling the Chipmunk C library, depending on whether the crate is being compiled with the debug profile (`cargo build`) or the release profile (`cargo build --release`).
- The `-DNDEBUG` flag is now passed for the release profile. This disables certain debug output and assertions in the Chipmunk library.
- The `-g` flag (to add debug information to the compiled library) is now only passed for the debug profile. Before, it was being passed regardless of what profile was being used.
