### PR TITLE
Implement From trait for cpVect ⟷ tuple and array

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,6 @@ description = "System level bindings to the chipmunk 2d game engine."
 
 build = "build.rs"
 
-lib = "chipmunk_sys"
-
 [dependencies]
 libc = "*"
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -20,19 +20,19 @@ fn main() { unsafe {
 
   let moment = cpMomentForCircle(mass, 0.0, radius, zero);
 
-  let ballbody = cpSpaceAddBody(space, cpBodyNew(mass, moment));
-  cpBodySetPosition(ballbody, cpv(0.0, 15.0));
+  let ball_body = cpSpaceAddBody(space, cpBodyNew(mass, moment));
+  cpBodySetPosition(ball_body, cpv(0.0, 15.0));
 
-  let ballShape = cpSpaceAddShape(space, cpCircleShapeNew(ballbody, radius, zero));
-  cpShapeSetFriction(ballShape, 0.7);
+  let ball_shape = cpSpaceAddShape(space, cpCircleShapeNew(ball_body, radius, zero));
+  cpShapeSetFriction(ball_shape, 0.7);
 
-  let timeStep = 1.0 / 60.0;
+  let time_step = 1.0 / 60.0;
   for i in 0 .. 60 {
-      let time = timeStep * i as f32;
-      let pos = cpBodyGetPosition(ballbody);
-      let vel = cpBodyGetVelocity(ballbody);
+      let time = time_step * i as f32;
+      let pos = cpBodyGetPosition(ball_body);
+      let vel = cpBodyGetVelocity(ball_body);
       println!("Time: {:?}, Pos: {:?}, Vel: {:?}", time, pos, vel);
-      cpSpaceStep(space, timeStep as f64);
+      cpSpaceStep(space, time_step as f64);
   }
 
 }}

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,6 +1,6 @@
-extern crate "chipmunk-sys" as chipsys;
+extern crate chipmunk_sys;
 
-use chipsys::*;
+use chipmunk_sys::*;
 
 fn main() { unsafe {
     let gravity = cpv(0.0, -100.0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ impl ::std::default::Default for Struct_cpVect {
 }
 pub type cpVect = Struct_cpVect;
 impl Struct_cpVect {
+    #[deprecated(note="Use v.into() or From::from(v) instead of v.to_tuple().")]
     pub fn to_tuple(&self) -> (cpFloat, cpFloat) {
         (self.x, self.y)
     }
@@ -31,6 +32,41 @@ impl Struct_cpVect {
 pub fn cpv(x: cpFloat, y: cpFloat) -> cpVect {
     cpVect{x: x, y:y}
 }
+
+impl From<cpVect> for (cpFloat, cpFloat) {
+    fn from(vect: cpVect) -> (cpFloat, cpFloat) {
+        (vect.x, vect.y)
+    }
+}
+
+impl<'a> From<&'a cpVect> for (cpFloat, cpFloat) {
+    fn from(vect: &'a cpVect) -> (cpFloat, cpFloat) {
+        (vect.x, vect.y)
+    }
+}
+
+impl From<(cpFloat, cpFloat)> for cpVect {
+    fn from(tuple: (cpFloat, cpFloat)) -> cpVect {
+        cpVect { x: tuple.0, y: tuple.1 }
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_cpvect_from_into() {
+    let v = cpVect::from((1.2, 3.4));
+    assert_eq!(1.2, v.x);
+    assert_eq!(3.4, v.y);
+    assert_eq!((1.2, 3.4), From::from(v));
+    assert_eq!((1.2, 3.4), From::from(&v));
+
+    let v2: cpVect = (5.6, 7.8).into();
+    assert_eq!(5.6, v2.x);
+    assert_eq!(7.8, v2.y);
+    assert_eq!((5.6, 7.8), v2.into());
+    assert_eq!((5.6, 7.8), (&v2).into());
+}
+
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ impl ::std::default::Default for Struct_cpVect {
 }
 pub type cpVect = Struct_cpVect;
 impl Struct_cpVect {
-    fn to_tuple(&self) -> (cpFloat, cpFloat) {
+    pub fn to_tuple(&self) -> (cpFloat, cpFloat) {
         (self.x, self.y)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#![allow(non_snake_case)]
+#![allow(non_camel_case_types)]
+
 extern crate libc;
 
 pub type cpFloat = ::libc::c_double;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,27 +33,43 @@ pub fn cpv(x: cpFloat, y: cpFloat) -> cpVect {
     cpVect{x: x, y:y}
 }
 
+// Converting cpVect to and from a tuple
 impl From<cpVect> for (cpFloat, cpFloat) {
     fn from(vect: cpVect) -> (cpFloat, cpFloat) {
         (vect.x, vect.y)
     }
 }
-
 impl<'a> From<&'a cpVect> for (cpFloat, cpFloat) {
     fn from(vect: &'a cpVect) -> (cpFloat, cpFloat) {
         (vect.x, vect.y)
     }
 }
-
 impl From<(cpFloat, cpFloat)> for cpVect {
     fn from(tuple: (cpFloat, cpFloat)) -> cpVect {
         cpVect { x: tuple.0, y: tuple.1 }
     }
 }
 
+// Converting cpVect to and from an array
+impl From<cpVect> for [cpFloat; 2] {
+    fn from(vect: cpVect) -> [cpFloat; 2] {
+        [vect.x, vect.y]
+    }
+}
+impl<'a> From<&'a cpVect> for [cpFloat; 2] {
+    fn from(vect: &'a cpVect) -> [cpFloat; 2] {
+        [vect.x, vect.y]
+    }
+}
+impl From<[cpFloat; 2]> for cpVect {
+    fn from(array: [cpFloat; 2]) -> cpVect {
+        cpVect { x: array[0], y: array[1] }
+    }
+}
+
 #[cfg(test)]
 #[test]
-fn test_cpvect_from_into() {
+fn test_cpvect_from_into_tuple() {
     let v = cpVect::from((1.2, 3.4));
     assert_eq!(1.2, v.x);
     assert_eq!(3.4, v.y);
@@ -65,6 +81,22 @@ fn test_cpvect_from_into() {
     assert_eq!(7.8, v2.y);
     assert_eq!((5.6, 7.8), v2.into());
     assert_eq!((5.6, 7.8), (&v2).into());
+}
+
+#[cfg(test)]
+#[test]
+fn test_cpvect_from_into_array() {
+    let v = cpVect::from([1.2, 3.4]);
+    assert_eq!(1.2, v.x);
+    assert_eq!(3.4, v.y);
+    assert_eq!([1.2, 3.4], <[f64; 2]>::from(v));
+    assert_eq!([1.2, 3.4], <[f64; 2]>::from(&v));
+
+    let v2: cpVect = [5.6, 7.8].into();
+    assert_eq!(5.6, v2.x);
+    assert_eq!(7.8, v2.y);
+    assert_eq!([5.6, 7.8], { let a: [f64; 2] = v2.into(); a });
+    assert_eq!([5.6, 7.8], { let a: [f64; 2] = (&v2).into(); a });
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1014,7 +1014,7 @@ extern "C" {
      -> ();
     pub fn cpArbiterGetFriction(arb: *const cpArbiter) -> cpFloat;
     pub fn cpArbiterSetFriction(arb: *mut cpArbiter, friction: cpFloat) -> ();
-    pub fn cpArbiterGetSurfaceVelocity(arb: *mut cpArbiter) -> cpVect;
+    pub fn cpArbiterGetSurfaceVelocity(arb: *const cpArbiter) -> cpVect;
     pub fn cpArbiterSetSurfaceVelocity(arb: *mut cpArbiter, vr: cpVect) -> ();
     pub fn cpArbiterGetUserData(arb: *const cpArbiter) -> cpDataPointer;
     pub fn cpArbiterSetUserData(arb: *mut cpArbiter, userData: cpDataPointer)
@@ -1070,7 +1070,7 @@ extern "C" {
     pub fn cpBodySleep(body: *mut cpBody) -> ();
     pub fn cpBodySleepWithGroup(body: *mut cpBody, group: *mut cpBody) -> ();
     pub fn cpBodyIsSleeping(body: *const cpBody) -> cpBool;
-    pub fn cpBodyGetType(body: *mut cpBody) -> cpBodyType;
+    pub fn cpBodyGetType(body: *const cpBody) -> cpBodyType;
     pub fn cpBodySetType(body: *mut cpBody, _type: cpBodyType) -> ();
     pub fn cpBodyGetSpace(body: *const cpBody) -> *mut cpSpace;
     pub fn cpBodyGetMass(body: *const cpBody) -> cpFloat;
@@ -1147,8 +1147,8 @@ extern "C" {
     pub fn cpShapeGetDensity(shape: *const cpShape) -> cpFloat;
     pub fn cpShapeSetDensity(shape: *mut cpShape, density: cpFloat) -> ();
     pub fn cpShapeGetMoment(shape: *const cpShape) -> cpFloat;
-    pub fn cpShapeGetArea(shape: *mut cpShape) -> cpFloat;
-    pub fn cpShapeGetCenterOfGravity(shape: *mut cpShape) -> cpVect;
+    pub fn cpShapeGetArea(shape: *const cpShape) -> cpFloat;
+    pub fn cpShapeGetCenterOfGravity(shape: *const cpShape) -> cpVect;
     pub fn cpShapeGetBB(shape: *const cpShape) -> cpBB;
     pub fn cpShapeGetSensor(shape: *const cpShape) -> cpBool;
     pub fn cpShapeSetSensor(shape: *mut cpShape, sensor: cpBool) -> ();
@@ -1252,7 +1252,7 @@ extern "C" {
      -> cpDataPointer;
     pub fn cpConstraintSetUserData(constraint: *mut cpConstraint,
                                    userData: cpDataPointer) -> ();
-    pub fn cpConstraintGetImpulse(constraint: *mut cpConstraint) -> cpFloat;
+    pub fn cpConstraintGetImpulse(constraint: *const cpConstraint) -> cpFloat;
     pub fn cpConstraintIsPinJoint(constraint: *const cpConstraint) -> cpBool;
     pub fn cpPinJointAlloc() -> *mut cpPinJoint;
     pub fn cpPinJointInit(joint: *mut cpPinJoint, a: *mut cpBody,
@@ -1507,12 +1507,12 @@ extern "C" {
     pub fn cpSpaceRemoveBody(space: *mut cpSpace, body: *mut cpBody) -> ();
     pub fn cpSpaceRemoveConstraint(space: *mut cpSpace,
                                    constraint: *mut cpConstraint) -> ();
-    pub fn cpSpaceContainsShape(space: *mut cpSpace, shape: *mut cpShape)
+    pub fn cpSpaceContainsShape(space: *const cpSpace, shape: *const cpShape)
      -> cpBool;
-    pub fn cpSpaceContainsBody(space: *mut cpSpace, body: *mut cpBody)
+    pub fn cpSpaceContainsBody(space: *const cpSpace, body: *const cpBody)
      -> cpBool;
-    pub fn cpSpaceContainsConstraint(space: *mut cpSpace,
-                                     constraint: *mut cpConstraint) -> cpBool;
+    pub fn cpSpaceContainsConstraint(space: *const cpSpace,
+                                     constraint: *const cpConstraint) -> cpBool;
     pub fn cpSpaceAddPostStepCallback(space: *mut cpSpace,
                                       func: cpPostStepFunc,
                                       key: *mut ::libc::c_void,
@@ -1608,7 +1608,7 @@ extern "C" {
     pub fn cpArrayPop(arr: *mut cpArray) -> *mut ::libc::c_void;
     pub fn cpArrayDeleteObj(arr: *mut cpArray, obj: *mut ::libc::c_void)
      -> ();
-    pub fn cpArrayContains(arr: *mut cpArray, ptr: *mut ::libc::c_void)
+    pub fn cpArrayContains(arr: *const cpArray, ptr: *const ::libc::c_void)
      -> cpBool;
     pub fn cpArrayFreeEach(arr: *mut cpArray, freeFunc: ::libc::c_void) -> ();
     pub fn cpHashSetNew(size: ::libc::c_int, eqlFunc: cpHashSetEqlFunc)


### PR DESCRIPTION
I have implemented the standard [From trait](https://doc.rust-lang.org/std/convert/trait.From.html) for converting a `cpVect` or `&cpVect` into a `(cpFloat, cpFloat)` tuple or `[cpFloat; 2]` array, which are the same as `(f64, f64)` and `[f64; 2]`. I have also implemented the trait for the opposite direction, converting a tuple or array into a cpVect. This makes it very easy to convert back and forth, which can simplify a lot of code in the chipmunk crate, or anyone who uses the chipmunk-sys crate directly.

Implementing the From trait also gives us the [Into trait](https://doc.rust-lang.org/std/convert/trait.Into.html) automatically.

This makes the `cpVect::to_tuple()` function obsolete. You can write `v.into()` or `<(f64, f64)>::from(v)` instead of `v.to_tuple()`. I have marked `cpVect::to_tuple()` as deprecated. It doesn't exist in any released version of this crate, but it is used by the master branch of the chipmunk crate, so I didn't want to remove it completely yet.

This pull request is based on the commits in pull request #2. I recommend merging that pull request first.
